### PR TITLE
Make rendering of Plot github-view-compatible

### DIFF
--- a/kandy-lets-plot/src/main/kotlin/org/jetbrains/kotlinx/kandy/letsplot/jupyter/Integration.kt
+++ b/kandy-lets-plot/src/main/kotlin/org/jetbrains/kotlinx/kandy/letsplot/jupyter/Integration.kt
@@ -5,20 +5,25 @@
 package org.jetbrains.kotlinx.kandy.letsplot.jupyter
 
 import jetbrains.datalore.plot.PlotHtmlHelper
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import org.jetbrains.kotlinx.jupyter.api.HTML
 import org.jetbrains.kotlinx.jupyter.api.MimeTypedResultEx
+import org.jetbrains.kotlinx.jupyter.api.MimeTypes
 import org.jetbrains.kotlinx.jupyter.api.Notebook
 import org.jetbrains.kotlinx.jupyter.api.annotations.JupyterLibrary
 import org.jetbrains.kotlinx.jupyter.api.declare
 import org.jetbrains.kotlinx.jupyter.api.libraries.JupyterIntegration
 import org.jetbrains.kotlinx.jupyter.api.libraries.resources
 import org.jetbrains.kotlinx.kandy.ir.Plot
+import org.jetbrains.kotlinx.kandy.letsplot.export.toBufferedImage
 import org.jetbrains.kotlinx.kandy.letsplot.multiplot.model.PlotBunch
 import org.jetbrains.kotlinx.kandy.letsplot.multiplot.model.PlotGrid
 import org.jetbrains.kotlinx.kandy.letsplot.translator.toLetsPlot
 import org.jetbrains.kotlinx.kandy.letsplot.translator.wrap
+import org.jetbrains.kotlinx.kandy.letsplot.util.extendedByJson
+import org.jetbrains.kotlinx.kandy.letsplot.util.toBase64EncodedString
 import org.jetbrains.kotlinx.kandy.util.serialization.serializeSpec
 import org.jetbrains.letsPlot.Figure
 import org.jetbrains.letsPlot.GGBunch
@@ -26,6 +31,7 @@ import org.jetbrains.letsPlot.LetsPlot
 import org.jetbrains.letsPlot.frontend.NotebookFrontendContext
 import org.jetbrains.letsPlot.intern.figure.SubPlotsFigure
 import org.jetbrains.letsPlot.intern.toSpec
+import java.util.UUID
 
 @JupyterLibrary
 internal class Integration(
@@ -91,30 +97,44 @@ internal class Integration(
             declare("kandyConfig" to config)
         }
 
-        fun Figure.toMimeResult(): MimeTypedResultEx {
+        fun Figure.toMimeJson(): JsonObject {
             val spec = toSpec()
-            /*when (this) {
-                is org.jetbrains.letsPlot.intern.Plot -> spec.applyColorSchemeToPlotSpec()
-                is SubPlotsFigure -> spec.applyColorSchemeToPlotGrid()
-                is GGBunch -> spec.applyColorSchemeToGGBunch()
-                else -> error("Unsupported Figure")
-            }*/
             val html = toHTML()
-            return MimeTypedResultEx(
-                buildJsonObject {
-                    put("text/html", JsonPrimitive(html))
-                    put("application/plot+json", buildJsonObject {
-                        put("output_type", JsonPrimitive("lets_plot_spec"))
-                        put("output", serializeSpec(spec))
-                        put("apply_color_scheme", JsonPrimitive(config.applyColorScheme))
-                        put("swing_enabled", JsonPrimitive(config.swingEnabled))
-                    })
-                }
-            )
+            return buildJsonObject {
+                put(MimeTypes.HTML, JsonPrimitive(html))
+                put("application/plot+json", buildJsonObject {
+                    put("output_type", JsonPrimitive("lets_plot_spec"))
+                    put("output", serializeSpec(spec))
+                    put("apply_color_scheme", JsonPrimitive(config.applyColorScheme))
+                    put("swing_enabled", JsonPrimitive(config.swingEnabled))
+                })
+            }
         }
 
+        fun Figure.toMimeResult(): MimeTypedResultEx {
+            return MimeTypedResultEx(toMimeJson())
+        }
 
-        render<Plot> { it.toLetsPlot().toMimeResult() }
+        fun Plot.toMimeResult(): MimeTypedResultEx {
+            val basicResult = toLetsPlot().toMimeJson()
+
+            val format = "png"
+            val scale = 4.0
+            val img = toBufferedImage(scale, 500)
+            val realWidth = (img.width / scale).toInt()
+            val encodedImage = img.toBase64EncodedString(format)
+            val id = UUID.randomUUID().toString()
+            val extraHTML = """
+                
+                <img id="$id" width="$realWidth" src="data:image/$format;base64,$encodedImage"/>
+                <script>document.getElementById("$id").style.display = "none";</script>
+            """.trimIndent()
+
+            val extraResult = mapOf(MimeTypes.HTML to JsonPrimitive(extraHTML))
+            return MimeTypedResultEx(basicResult extendedByJson extraResult)
+        }
+
+        render<Plot> { it.toMimeResult() }
         render<PlotBunch> { it.wrap().toMimeResult() }
         render<PlotGrid> { it.wrap().toMimeResult() }
     }

--- a/kandy-lets-plot/src/main/kotlin/org/jetbrains/kotlinx/kandy/letsplot/util/containerUtil.kt
+++ b/kandy-lets-plot/src/main/kotlin/org/jetbrains/kotlinx/kandy/letsplot/util/containerUtil.kt
@@ -1,0 +1,38 @@
+package org.jetbrains.kotlinx.kandy.letsplot.util
+
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+internal fun <K, T: Any> Map<K, T>.extendedBy(other: Map<K, T>, join: (T, T) -> T): Map<K, T> {
+    val ours = this
+    return buildMap {
+        for ((k, v) in ours) {
+            val otherV = other[k]
+            val finalV = if (otherV == null) v else join(v, otherV)
+            put(k, finalV)
+        }
+        for ((k, v) in other) {
+            if (k !in ours) {
+                put(k, v)
+            }
+        }
+    }
+}
+
+
+internal infix fun Map<String, JsonElement>.extendedByJson(other: Map<String, JsonElement>): JsonObject {
+    val map = this.extendedBy(other) { a, b ->
+        // This logic might be enhanced
+        when {
+            a is JsonPrimitive && a.isString -> {
+                when {
+                    b is JsonPrimitive && b.isString -> JsonPrimitive(a.content + b.content)
+                    else -> a
+                }
+            }
+            else -> a
+        }
+    }
+    return JsonObject(map)
+}

--- a/kandy-lets-plot/src/main/kotlin/org/jetbrains/kotlinx/kandy/letsplot/util/containerUtil.kt
+++ b/kandy-lets-plot/src/main/kotlin/org/jetbrains/kotlinx/kandy/letsplot/util/containerUtil.kt
@@ -1,36 +1,33 @@
 package org.jetbrains.kotlinx.kandy.letsplot.util
 
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
 
-internal fun <K, T: Any> Map<K, T>.extendedBy(other: Map<K, T>, join: (T, T) -> T): Map<K, T> {
-    val ours = this
-    return buildMap {
-        for ((k, v) in ours) {
-            val otherV = other[k]
-            val finalV = if (otherV == null) v else join(v, otherV)
-            put(k, finalV)
-        }
-        for ((k, v) in other) {
-            if (k !in ours) {
-                put(k, v)
-            }
-        }
+internal fun <K, V: Any> Map<K, V>.extendedBy(other: Map<K, V>, join: (V, V) -> V): Map<K, V> {
+    return (this + other).mapValues { (k, v) ->
+        if (k in this && k in other)
+            join(this[k]!!, other[k]!!)
+        else
+            v
     }
 }
-
+@OptIn(ExperimentalContracts::class)
+private fun isStringLiteral(element: JsonElement): Boolean {
+    contract { returns(true) implies (element is JsonPrimitive) }
+    return element is JsonPrimitive && element.isString
+}
 
 internal infix fun Map<String, JsonElement>.extendedByJson(other: Map<String, JsonElement>): JsonObject {
     val map = this.extendedBy(other) { a, b ->
         // This logic might be enhanced
         when {
-            a is JsonPrimitive && a.isString -> {
-                when {
-                    b is JsonPrimitive && b.isString -> JsonPrimitive(a.content + b.content)
-                    else -> a
-                }
-            }
+            isStringLiteral(a) && isStringLiteral(b) -> JsonPrimitive(a.content + b.content)
+            a is JsonArray && b is JsonArray -> JsonArray(a + b)
+            a is JsonObject && b is JsonObject -> JsonObject(a + b)
             else -> a
         }
     }

--- a/kandy-lets-plot/src/main/kotlin/org/jetbrains/kotlinx/kandy/letsplot/util/rendering.kt
+++ b/kandy-lets-plot/src/main/kotlin/org/jetbrains/kotlinx/kandy/letsplot/util/rendering.kt
@@ -1,0 +1,14 @@
+package org.jetbrains.kotlinx.kandy.letsplot.util
+
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import java.util.*
+import javax.imageio.ImageIO
+
+internal fun BufferedImage.toBase64EncodedString(format: String = "png"): String {
+    val stream = ByteArrayOutputStream()
+    ImageIO.write(this, format, stream)
+    val data = stream.toByteArray()
+    val encoder = Base64.getEncoder()
+    return encoder.encodeToString(data)
+}

--- a/kandy-lets-plot/src/main/kotlin/org/jetbrains/kotlinx/kandy/letsplot/util/rendering.kt
+++ b/kandy-lets-plot/src/main/kotlin/org/jetbrains/kotlinx/kandy/letsplot/util/rendering.kt
@@ -1,14 +1,62 @@
 package org.jetbrains.kotlinx.kandy.letsplot.util
 
-import java.awt.image.BufferedImage
-import java.io.ByteArrayOutputStream
+import jetbrains.datalore.plot.PlotSvgExport
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import org.jetbrains.kotlinx.jupyter.api.MimeTypedResultEx
+import org.jetbrains.kotlinx.jupyter.api.MimeTypes
+import org.jetbrains.kotlinx.kandy.letsplot.jupyter.JupyterConfig
+import org.jetbrains.kotlinx.kandy.util.serialization.serializeSpec
+import org.jetbrains.letsPlot.Figure
+import org.jetbrains.letsPlot.GGBunch
+import org.jetbrains.letsPlot.frontend.NotebookFrontendContext
+import org.jetbrains.letsPlot.intern.figure.SubPlotsFigure
+import org.jetbrains.letsPlot.intern.toSpec
 import java.util.*
-import javax.imageio.ImageIO
 
-internal fun BufferedImage.toBase64EncodedString(format: String = "png"): String {
-    val stream = ByteArrayOutputStream()
-    ImageIO.write(this, format, stream)
-    val data = stream.toByteArray()
-    val encoder = Base64.getEncoder()
-    return encoder.encodeToString(data)
+internal class NotebookRenderingContext(
+    val frontendContext: NotebookFrontendContext,
+    val config: JupyterConfig,
+)
+
+internal fun NotebookRenderingContext.figureToHtml(figure: Figure): String {
+    return when (figure) {
+        is org.jetbrains.letsPlot.intern.Plot -> frontendContext.getHtml(figure)
+        is SubPlotsFigure -> frontendContext.getHtml(figure)
+        is GGBunch -> frontendContext.getHtml(figure)
+        else -> error("Unsupported Figure")
+    }
+}
+
+internal fun NotebookRenderingContext.figureToMimeJson(figure: Figure): JsonObject {
+    val spec = figure.toSpec()
+    val html = figureToHtml(figure)
+    return buildJsonObject {
+        put(MimeTypes.HTML, JsonPrimitive(html))
+        put("application/plot+json", buildJsonObject {
+            put("output_type", JsonPrimitive("lets_plot_spec"))
+            put("output", serializeSpec(spec))
+            put("apply_color_scheme", JsonPrimitive(config.applyColorScheme))
+            put("swing_enabled", JsonPrimitive(config.swingEnabled))
+        })
+    }
+}
+
+internal fun NotebookRenderingContext.figureToMimeResult(figure: Figure): MimeTypedResultEx {
+    val basicResult = figureToMimeJson(figure)
+
+    val plotSVG = PlotSvgExport.buildSvgImageFromRawSpecs(figure.toSpec())
+    val id = UUID.randomUUID().toString()
+    val svgWithID = with(plotSVG) {
+        take(4) + " id=$id" + drop(4)
+    }
+    val extraHTML = """
+        
+        $svgWithID
+        <script>document.getElementById("$id").style.display = "none";</script>
+    """.trimIndent()
+
+    val extraResult = mapOf(MimeTypes.HTML to JsonPrimitive(extraHTML))
+    return MimeTypedResultEx(basicResult extendedByJson extraResult)
 }


### PR DESCRIPTION
We add an image with plot which is immediately hidden by JS under it. Github view doesn't execute JS, that's why on Github we see this image instead of JS-rendered plot.

See example notebook here: https://gist.github.com/ileasile/ea7e65a1d35d5175712d7ef94fd5fd95