### PR TITLE
Documentation fix - removed duplicate terms path, pie and pointRanges

### DIFF
--- a/docs/topics/Getting-Started.md
+++ b/docs/topics/Getting-Started.md
@@ -189,9 +189,6 @@ providing a quick reference to assist you in building your visualizations.
 <li>path</li>
 <li>pie</li>
 <li>pointRanges</li>
-<li>path</li>
-<li>pie</li>
-<li>pointRanges</li>
 <li>raster</li>
 <li>rectangles</li>
 <li>ribbon</li>


### PR DESCRIPTION
In the tree of layer reference, terms 'path', 'pie' and 'pointRanges' are no longer duplicates

Link to issue - https://github.com/Kotlin/kandy/issues/313

