### PR TITLE
added extension functions to export plots to jpg and png bytearrays

### DIFF
--- a/kandy-lets-plot/src/main/kotlin/org/jetbrains/kotlinx/kandy/letsplot/export/toBufferedImage.kt
+++ b/kandy-lets-plot/src/main/kotlin/org/jetbrains/kotlinx/kandy/letsplot/export/toBufferedImage.kt
@@ -14,17 +14,21 @@ import java.awt.image.BufferedImage
 import java.io.ByteArrayInputStream
 import javax.imageio.ImageIO
 import org.jetbrains.kotlinx.kandy.letsplot.translator.wrap
+import java.io.ByteArrayOutputStream
 
 /**
  * Convert plot spec to `BufferedImage`
  *
  * @receiver the plot spec represented as `MutableMap`
  */
-internal fun MutableMap<String, Any>.toBufferedImage(scale: Number = 1, dpi: Number? = null): BufferedImage {
+internal fun MutableMap<String, Any>.toBufferedImage(
+    scale: Number = 1,
+    dpi: Number? = null
+): BufferedImage {
     val byteArray = PlotImageExport.buildImageFromRawSpecs(
         this,
         PlotImageExport.Format.PNG,
-        scale.toDouble(),dpi?.toDouble() ?: Double.NaN
+        scale.toDouble(), dpi?.toDouble() ?: Double.NaN
     ).bytes
     return ImageIO.read(ByteArrayInputStream(byteArray))
 }
@@ -46,7 +50,57 @@ internal fun MutableMap<String, Any>.toBufferedImage(scale: Number = 1, dpi: Num
 public fun Plot.toBufferedImage(
     scale: Number = 1,
     dpi: Number? = null,
-): BufferedImage =  this.toLetsPlot().toSpec().toBufferedImage(scale, dpi)
+): BufferedImage = this.toLetsPlot().toSpec().toBufferedImage(scale, dpi)
+
+/**
+ * Exports the current plot grid as a [ByteArray] in the JPG format.
+ *
+ * The parameters [scale] and [dpi] influence the quality and size of the rasterized image.
+ *
+ * @receiver [Plot] - the plot grid to export.
+ * @param scale the scaling is applied to the plot when converting to a raster format (PNG).
+ * It affects the resolution and size of the resulting [BufferedImage].
+ * The default value is 1.
+ * @param dpi the resolution of the exported image in dots per inch (DPI).
+ * This parameter influences the quality of the rasterized image, with a higher value resulting in better quality.
+ * By default, no specific DPI value is assigned, and it utilizes the system's default settings.
+ * @return [ByteArray] the created image representing the plot grid.
+ */
+
+public fun Plot.toJPG(
+    scale: Number = 1,
+    dpi: Number? = null,
+): ByteArray {
+    val bufferedImage = this.toLetsPlot().toSpec().toBufferedImage(scale, dpi)
+    val outputStream = ByteArrayOutputStream()
+    ImageIO.write(bufferedImage, "JPEG", outputStream)
+    return outputStream.toByteArray()
+}
+
+/**
+ * Exports the current plot grid as a [ByteArray] in the PNG format.
+ *
+ * The parameters [scale] and [dpi] influence the quality and size of the rasterized image.
+ *
+ * @receiver [Plot] - the plot grid to export.
+ * @param scale the scaling is applied to the plot when converting to a raster format (PNG).
+ * It affects the resolution and size of the resulting [BufferedImage].
+ * The default value is 1.
+ * @param dpi the resolution of the exported image in dots per inch (DPI).
+ * This parameter influences the quality of the rasterized image, with a higher value resulting in better quality.
+ * By default, no specific DPI value is assigned, and it utilizes the system's default settings.
+ * @return [ByteArray] the created image representing the plot grid.
+ */
+
+public fun Plot.toPNG(
+    scale: Number = 1,
+    dpi: Number? = null,
+): ByteArray {
+    val bufferedImage = this.toLetsPlot().toSpec().toBufferedImage(scale, dpi)
+    val outputStream = ByteArrayOutputStream()
+    ImageIO.write(bufferedImage, "PNG", outputStream)
+    return outputStream.toByteArray()
+}
 
 /**
  * Exports the current plot grid as a [BufferedImage].
@@ -65,7 +119,57 @@ public fun Plot.toBufferedImage(
 public fun PlotGrid.toBufferedImage(
     scale: Number = 1,
     dpi: Number? = null,
-): BufferedImage =  this.wrap().toSpec().toBufferedImage(scale, dpi)
+): BufferedImage = this.wrap().toSpec().toBufferedImage(scale, dpi)
+
+/**
+ * Exports the current plot grid as a [ByteArray] in the JPG format.
+ *
+ * The parameters [scale] and [dpi] influence the quality and size of the rasterized image.
+ *
+ * @receiver [PlotGrid] - the plot grid to export.
+ * @param scale the scaling is applied to the plot when converting to a raster format (PNG).
+ * It affects the resolution and size of the resulting [BufferedImage].
+ * The default value is 1.
+ * @param dpi the resolution of the exported image in dots per inch (DPI).
+ * This parameter influences the quality of the rasterized image, with a higher value resulting in better quality.
+ * By default, no specific DPI value is assigned, and it utilizes the system's default settings.
+ * @return [ByteArray] the created image representing the plot grid.
+ */
+
+public fun PlotGrid.toJPG(
+    scale: Number = 1,
+    dpi: Number? = null,
+): ByteArray {
+    val bufferedImage = this.wrap().toSpec().toBufferedImage(scale, dpi)
+    val outputStream = ByteArrayOutputStream()
+    ImageIO.write(bufferedImage, "JPEG", outputStream)
+    return outputStream.toByteArray()
+}
+
+/**
+ * Exports the current plot grid as a [ByteArray] in the PNG format.
+ *
+ * The parameters [scale] and [dpi] influence the quality and size of the rasterized image.
+ *
+ * @receiver [PlotGrid] - the plot grid to export.
+ * @param scale the scaling is applied to the plot when converting to a raster format (PNG).
+ * It affects the resolution and size of the resulting [BufferedImage].
+ * The default value is 1.
+ * @param dpi the resolution of the exported image in dots per inch (DPI).
+ * This parameter influences the quality of the rasterized image, with a higher value resulting in better quality.
+ * By default, no specific DPI value is assigned, and it utilizes the system's default settings.
+ * @return [ByteArray] the created image representing the plot grid.
+ */
+
+public fun PlotGrid.toPNG(
+    scale: Number = 1,
+    dpi: Number? = null,
+): ByteArray {
+    val bufferedImage = this.wrap().toSpec().toBufferedImage(scale, dpi)
+    val outputStream = ByteArrayOutputStream()
+    ImageIO.write(bufferedImage, "PNG", outputStream)
+    return outputStream.toByteArray()
+}
 
 /**
  * Exports the current plot bunch as a [BufferedImage].
@@ -84,4 +188,54 @@ public fun PlotGrid.toBufferedImage(
 public fun PlotBunch.toBufferedImage(
     scale: Number = 1,
     dpi: Number? = null,
-): BufferedImage =  this.wrap().toSpec().toBufferedImage(scale, dpi)
+): BufferedImage = this.wrap().toSpec().toBufferedImage(scale, dpi)
+
+/**
+ * Exports the current plot grid as a [ByteArray] in the JPG format.
+ *
+ * The parameters [scale] and [dpi] influence the quality and size of the rasterized image.
+ *
+ * @receiver [PlotBunch] - the plot grid to export.
+ * @param scale the scaling is applied to the plot when converting to a raster format (PNG).
+ * It affects the resolution and size of the resulting [BufferedImage].
+ * The default value is 1.
+ * @param dpi the resolution of the exported image in dots per inch (DPI).
+ * This parameter influences the quality of the rasterized image, with a higher value resulting in better quality.
+ * By default, no specific DPI value is assigned, and it utilizes the system's default settings.
+ * @return [ByteArray] the created image representing the plot grid.
+ */
+
+public fun PlotBunch.toJPG(
+    scale: Number = 1,
+    dpi: Number? = null,
+): ByteArray {
+    val bufferedImage = this.wrap().toSpec().toBufferedImage(scale, dpi)
+    val outputStream = ByteArrayOutputStream()
+    ImageIO.write(bufferedImage, "JPEG", outputStream)
+    return outputStream.toByteArray()
+}
+
+/**
+ * Exports the current plot grid as a [ByteArray] in the PNG format.
+ *
+ * The parameters [scale] and [dpi] influence the quality and size of the rasterized image.
+ *
+ * @receiver [PlotBunch] - the plot grid to export.
+ * @param scale the scaling is applied to the plot when converting to a raster format (PNG).
+ * It affects the resolution and size of the resulting [BufferedImage].
+ * The default value is 1.
+ * @param dpi the resolution of the exported image in dots per inch (DPI).
+ * This parameter influences the quality of the rasterized image, with a higher value resulting in better quality.
+ * By default, no specific DPI value is assigned, and it utilizes the system's default settings.
+ * @return [ByteArray] the created image representing the plot grid.
+ */
+
+public fun PlotBunch.toPNG(
+    scale: Number = 1,
+    dpi: Number? = null,
+): ByteArray {
+    val bufferedImage = this.wrap().toSpec().toBufferedImage(scale, dpi)
+    val outputStream = ByteArrayOutputStream()
+    ImageIO.write(bufferedImage, "PNG", outputStream)
+    return outputStream.toByteArray()
+}

--- a/kandy-lets-plot/src/test/kotlin/org/jetbrains/kotlinx/kandy/letsplot/export/bufferedImage.kt
+++ b/kandy-lets-plot/src/test/kotlin/org/jetbrains/kotlinx/kandy/letsplot/export/bufferedImage.kt
@@ -26,6 +26,34 @@ class BufferedImageTest {
     }
 
     @Test
+    fun `export plot as JPG`() {
+        val plot: Plot = plot { line { x(listOf(1, 2, 3)); y(listOf(0.3, 0.15, 0.53)) } }
+        val scale = 2.0
+        val dpi = 300
+
+        val jpgImage = plot.toJPG(scale, dpi)
+
+        assertNotNull(jpgImage)
+
+        val jpgImageWithDifferentScale = plot.toJPG(1.0, dpi)
+        assertNotEquals(jpgImage, jpgImageWithDifferentScale)
+    }
+
+    @Test
+    fun `export plot as PNG`() {
+        val plot: Plot = plot { line { x(listOf(1, 2, 3)); y(listOf(0.3, 0.15, 0.53)) } }
+        val scale = 2.0
+        val dpi = 300
+
+        val pngImage = plot.toPNG(scale, dpi)
+
+        assertNotNull(pngImage)
+
+        val pngImageWithDifferentScale = plot.toPNG(1.0, dpi)
+        assertNotEquals(pngImage, pngImageWithDifferentScale)
+    }
+
+    @Test
     fun `export plot grid as BufferedImage`() {
         val plot: Plot = plot { line { x(listOf(1, 2, 3)); y(listOf(0.3, 0.15, 0.53)) } }
         val grid = plotGrid(listOf(plot, plot, plot))
@@ -39,6 +67,36 @@ class BufferedImageTest {
         val bufferedImageWithDifferentScale = grid.toBufferedImage(1.0, dpi)
         assertNotEquals(bufferedImage.width, bufferedImageWithDifferentScale.width)
         assertNotEquals(bufferedImage.height, bufferedImageWithDifferentScale.height)
+    }
+
+    @Test
+    fun `export plot grid as JPG`() {
+        val plot: Plot = plot { line { x(listOf(1, 2, 3)); y(listOf(0.3, 0.15, 0.53)) } }
+        val grid = plotGrid(listOf(plot, plot, plot))
+        val scale = 2.0
+        val dpi = 300
+
+        val jpgImage = grid.toJPG(scale, dpi)
+
+        assertNotNull(jpgImage)
+
+        val jpgImageWithDifferentScale = grid.toJPG(1.0, dpi)
+        assertNotEquals(jpgImage, jpgImageWithDifferentScale)
+    }
+
+    @Test
+    fun `export plot grid as PNG`() {
+        val plot: Plot = plot { line { x(listOf(1, 2, 3)); y(listOf(0.3, 0.15, 0.53)) } }
+        val grid = plotGrid(listOf(plot, plot, plot))
+        val scale = 2.0
+        val dpi = 300
+
+        val pngImage = grid.toPNG(scale, dpi)
+
+        assertNotNull(pngImage)
+
+        val pngImageWithDifferentScale = grid.toPNG(1.0, dpi)
+        assertNotEquals(pngImage, pngImageWithDifferentScale)
     }
 
     @Test
@@ -59,5 +117,43 @@ class BufferedImageTest {
         val bufferedImageWithDifferentScale = bunch.toBufferedImage(1.0, dpi)
         assertNotEquals(bufferedImage.width, bufferedImageWithDifferentScale.width)
         assertNotEquals(bufferedImage.height, bufferedImageWithDifferentScale.height)
+    }
+
+    @Test
+    fun `export plot bunch as JPG`() {
+        val plot: Plot = plot { line { x(listOf(1, 2, 3)); y(listOf(0.3, 0.15, 0.53)) } }
+        val bunch = plotBunch {
+            add(plot, 0, 0)
+            add(plot, 400, 600)
+            add(plot, 800, 600)
+        }
+        val scale = 2.0
+        val dpi = 300
+
+        val jpgImage = bunch.toJPG(scale, dpi)
+
+        assertNotNull(jpgImage)
+
+        val jpgImageWithDifferentScale = bunch.toJPG(1.0, dpi)
+        assertNotEquals(jpgImage, jpgImageWithDifferentScale)
+    }
+
+    @Test
+    fun `export plot bunch as PNG`() {
+        val plot: Plot = plot { line { x(listOf(1, 2, 3)); y(listOf(0.3, 0.15, 0.53)) } }
+        val bunch = plotBunch {
+            add(plot, 0, 0)
+            add(plot, 400, 600)
+            add(plot, 800, 600)
+        }
+        val scale = 2.0
+        val dpi = 300
+
+        val pngImage = bunch.toPNG(scale, dpi)
+
+        assertNotNull(pngImage)
+
+        val pngImageWithDifferentScale = bunch.toPNG(1.0, dpi)
+        assertNotEquals(pngImage, pngImageWithDifferentScale)
     }
 }


### PR DESCRIPTION
added these two extension functions for the plot, plot grid, and plot bunch which is used to export the plots to image byte arrays. Also written tests for these.

1. toPNG(): ByteArray
2. toJPG(): ByteArray

