### PR TITLE
add stroke aes to points and pointRanges layers

### DIFF
--- a/docs/topics/apiRef/PointRanges-API.md
+++ b/docs/topics/apiRef/PointRanges-API.md
@@ -72,6 +72,13 @@
         <format style="superscript">NonPositional</format>
         <emphasis>Double</emphasis>
     </li>
+    <li>
+        <a href="#innerpoint-stroke">
+            <format style="bold" color="DarkGray">stroke</format>
+        </a>
+        <format style="superscript">NonPositional</format>
+        <emphasis>(Iterable | Column | String) | Number</emphasis>
+    </li>
 </list>
 <format style="italic"> }</format>
 </li>
@@ -135,5 +142,11 @@
 <chapter title="innerPoint.fatten" collapsible="true" id="innerpoint-fatten">
 
 <include from="properties.topic" element-id="fatten-property"/>
+
+</chapter>
+
+<chapter title="innerPoint.stroke" collapsible="true" id="innerpoint-stroke">
+
+<include from="properties.topic" element-id="stroke-point-property"/>
 
 </chapter>

--- a/docs/topics/apiRef/Points-API.md
+++ b/docs/topics/apiRef/Points-API.md
@@ -32,6 +32,10 @@
 <a href="#size"><format style="bold" color="DarkGray">size</format></a> <format style="superscript">NonPositional</format>
 <include from="properties.topic" element-id="signature-of-nonpos-double"/>
 </li>
+<li>
+<a href="#stroke"><format style="bold" color="DarkGray">stroke</format></a> <format style="superscript">NonPositional</format>
+<emphasis>(Iterable | Column | String) | Number</emphasis>
+</li>
 </list>
 <format style="italic">}</format>
 </tldr>
@@ -65,3 +69,7 @@
 ### size
 
 <include from="properties.topic" element-id="size-property"/>
+
+### stroke
+
+<include from="properties.topic" element-id="stroke-point-property"/>

--- a/docs/topics/apiRef/properties.topic
+++ b/docs/topics/apiRef/properties.topic
@@ -342,6 +342,44 @@
         </list>
     </snippet>
 
+    <snippet id="stroke-point-property">
+        <p>
+            <format style="superscript" color="LightSlateGray">Optional</format>
+            <format style="superscript" color="#89CFF0">NonPositional</format>
+        </p>
+        <p>
+            <format style="superscript" color="#E8488B">Iterable</format>
+            <format style="superscript" color="#E8488B">Column</format>
+            <format style="superscript" color="#E8488B">String</format>
+            <format style="superscript" color="#E8488B">Double</format>
+        </p>
+
+        <p>
+            The <code>stroke</code> aesthetic affects the thickness of a symbol borders (shapes).
+            This aesthetic can be used on <code>pointRanges</code> and <code>points</code> layers.
+        </p>
+
+        <p><b>Setting</b></p>
+        <list>
+            <li>
+                <code>stroke = Number</code>: imposes a uniform size across all applicable elements within a layer.
+                The number value is factor indicating the thickness if the point boundaries, e.g., <code>size = 5</code>.
+            </li>
+        </list>
+        <p><b>Mapping</b></p>
+        <list>
+            <li><code>stroke(Iterable)</code>: each element's thickness is linked to a value from an iterable collection,
+                allowing for varied sizes within a layer to represent data variations.
+            </li>
+            <li><code>stroke(ColumnReference | KProperty | DataColumn)</code>: element thickness are associated with a
+                DataFrame column, enabling the visualization of data-driven size differences.
+            </li>
+            <li><code>stroke(String)</code>: thicknesses are tied to data based on the column name in the DataFrame or
+                by a key in a Map, facilitating flexible data representation through thickness of the point boundaries.
+            </li>
+        </list>
+    </snippet>
+
     <snippet id="symbol-property">
         <p>
             <format style="superscript" color="LightSlateGray">Optional</format>

--- a/kandy-lets-plot/src/main/kotlin/org/jetbrains/kotlinx/kandy/letsplot/layers/context/PointRanges.kt
+++ b/kandy-lets-plot/src/main/kotlin/org/jetbrains/kotlinx/kandy/letsplot/layers/context/PointRanges.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlinx.kandy.util.context.SelfInvocationContext
 
 
 public class InnerPointContext internal constructor(override val parentContext: BindingContext) :
-    SelfInvocationContext, SubBindingContext, WithSymbol, WithFillColor, WithFatten
+    SelfInvocationContext, SubBindingContext, WithSymbol, WithFillColor, WithFatten, WithPointStroke
 
 public class InnerLineContext internal constructor(override val parentContext: BindingContext) :
     SelfInvocationContext, SubBindingContext, WithType

--- a/kandy-lets-plot/src/main/kotlin/org/jetbrains/kotlinx/kandy/letsplot/layers/context/PointsContext.kt
+++ b/kandy-lets-plot/src/main/kotlin/org/jetbrains/kotlinx/kandy/letsplot/layers/context/PointsContext.kt
@@ -14,18 +14,17 @@ import org.jetbrains.kotlinx.kandy.letsplot.internal.Y
 import org.jetbrains.kotlinx.kandy.letsplot.layers.context.aes.*
 import org.jetbrains.kotlinx.kandy.letsplot.layers.geom.POINT
 
-// todo add Stroke
 /**
  * Interface defining the necessary aesthetics and methods for points layers.
  *
  * Points layers are primarily used in scatter plots to represent individual data points in two-dimensional space.
- * The interface provides aesthetics such as `x`, `y`, `color`, `symbol`, `size`, `alpha`, and `fillColor`
+ * The interface provides aesthetics such as `x`, `y`, `color`, `symbol`, `size`, `alpha`, `stroke`, and `fillColor`
  * to allow for a comprehensive customization of point representation.
  *
  * Required aesthetics for points layers are `x` and `y`.
  */
 public interface PointsInterface : LayerContextInterface, WithX, WithY, WithColor, WithSymbol,
-    WithSize, WithAlpha, WithFillColor {
+    WithSize, WithAlpha, WithFillColor, WithPointStroke {
 
     /**
      * Gets the Geom object specific to **points** layers.

--- a/kandy-lets-plot/src/main/kotlin/org/jetbrains/kotlinx/kandy/letsplot/layers/context/aes/WithPointStroke.kt
+++ b/kandy-lets-plot/src/main/kotlin/org/jetbrains/kotlinx/kandy/letsplot/layers/context/aes/WithPointStroke.kt
@@ -1,0 +1,120 @@
+package org.jetbrains.kotlinx.kandy.letsplot.layers.context.aes
+
+import org.jetbrains.kotlinx.dataframe.DataColumn
+import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
+import org.jetbrains.kotlinx.kandy.dsl.internal.BindingContext
+import org.jetbrains.kotlinx.kandy.ir.bindings.NonPositionalMapping
+import org.jetbrains.kotlinx.kandy.letsplot.internal.LetsPlotNonPositionalMappingParametersContinuous
+import org.jetbrains.kotlinx.kandy.letsplot.internal.STROKE
+import kotlin.reflect.KProperty
+
+/**
+ * Interface for managing the `stroke` aesthetic.
+ *
+ * Affects the thickness of the point boundaries (in case the given shape has a boundary).
+ */
+public interface WithPointStroke : BindingContext {
+
+    /**
+     *
+     * @property stroke a numeric value that represents the width of the stroke.
+     */
+    public var stroke: Number?
+        get() = null
+        set(value) {
+            addNonPositionalSetting(STROKE, value?.toDouble())
+        }
+
+    /**
+     * Maps the `stroke` aesthetic to a data column by [ColumnReference].
+     *
+     * @param column the data column to map to the size.
+     * @param parameters optional lambda to configure additional scale parameters.
+     * @return a [NonPositionalMapping] object representing the mapping.
+     */
+    public fun <T> stroke(
+        column: ColumnReference<T>,
+        parameters: LetsPlotNonPositionalMappingParametersContinuous<T, Double>.() -> Unit = {}
+    ): NonPositionalMapping<T, Double> {
+        return addNonPositionalMapping(
+            STROKE,
+            column.name(),
+            LetsPlotNonPositionalMappingParametersContinuous<T, Double>().apply(parameters)
+        )
+    }
+
+    /**
+     * Maps the `stroke` aesthetic to a data column by [KProperty].
+     *
+     * @param column the data column to map to the size.
+     * @param parameters optional lambda to configure additional scale parameters.
+     * @return a [NonPositionalMapping] object representing the mapping.
+     */
+    public fun <T> stroke(
+        column: KProperty<T>,
+        parameters: LetsPlotNonPositionalMappingParametersContinuous<T, Double>.() -> Unit = {}
+    ): NonPositionalMapping<T, Double> {
+        return addNonPositionalMapping(
+            STROKE,
+            column.name,
+            LetsPlotNonPositionalMappingParametersContinuous<T, Double>().apply(parameters)
+        )
+    }
+
+    /**
+     * Maps the `stroke` aesthetic to a data column by [String].
+     *
+     * @param column the data column to map to the size.
+     * @param parameters optional lambda to configure additional scale parameters.
+     * @return a [NonPositionalMapping] object representing the mapping.
+     */
+    public fun stroke(
+        column: String,
+        parameters: LetsPlotNonPositionalMappingParametersContinuous<Any?, Double>.() -> Unit = {}
+    ): NonPositionalMapping<Any?, Double> {
+        return addNonPositionalMapping(
+            STROKE,
+            column,
+            LetsPlotNonPositionalMappingParametersContinuous<Any?, Double>().apply(parameters)
+        )
+    }
+
+    /**
+     * Maps the `stroke` aesthetic to iterable of discrete values.
+     *
+     * @param values the iterable containing the discrete values.
+     * @param name optional name for this aesthetic mapping.
+     * @param parameters optional lambda to configure additional scale parameters.
+     * @return a [NonPositionalMapping] object representing the mapping.
+     */
+    public fun <T> stroke(
+        values: Iterable<T>,
+        name: String? = null,
+        parameters: LetsPlotNonPositionalMappingParametersContinuous<T, Double>.() -> Unit = {}
+    ): NonPositionalMapping<T, Double> {
+        return addNonPositionalMapping(
+            STROKE,
+            values.toList(),
+            name,
+            LetsPlotNonPositionalMappingParametersContinuous<T, Double>().apply(parameters)
+        )
+    }
+
+    /**
+     * Maps the `stroke` aesthetic to a data column.
+     *
+     * @param values the data column to map to the size.
+     * @param parameters optional lambda to configure additional scale parameters.
+     * @return a [NonPositionalMapping] object representing the mapping.
+     */
+    public fun <T> stroke(
+        values: DataColumn<T>,
+        parameters: LetsPlotNonPositionalMappingParametersContinuous<T, Double>.() -> Unit = {}
+    ): NonPositionalMapping<T, Double> {
+        return addNonPositionalMapping(
+            STROKE,
+            values,
+            LetsPlotNonPositionalMappingParametersContinuous<T, Double>().apply(parameters)
+        )
+    }
+}

--- a/kandy-lets-plot/src/main/kotlin/org/jetbrains/kotlinx/kandy/letsplot/layers/pointRanges.kt
+++ b/kandy-lets-plot/src/main/kotlin/org/jetbrains/kotlinx/kandy/letsplot/layers/pointRanges.kt
@@ -34,7 +34,8 @@ import org.jetbrains.kotlinx.kandy.letsplot.layers.context.PointRangesContext
  * * **`innerPoint.fatten`** - The amount to fatten the point relative to the line.
  * * **`innerPoint.symbol`** - The symbol used for the point.
  * * **`innerPoint.fillColor`** - The fill color of the symbol.
- * * **`innerPoint.symbol`** - The symbol used for the point.
+ * * **`innerPoint.stroke`** - Width of the shape border.
+ * Applied only to the shapes having border.
  *
  * ## Example
  *
@@ -68,6 +69,7 @@ import org.jetbrains.kotlinx.kandy.letsplot.layers.context.PointRangesContext
  *         innerPoint {
  *             symbol = Symbol.DIAMOND_FILLED // The symbol used for the point
  *             fillColor = Color.RED // The fill color of the symbol
+ *             stroke = 2
  *         }
  *
  *         color = Color.BLUE

--- a/kandy-lets-plot/src/main/kotlin/org/jetbrains/kotlinx/kandy/letsplot/layers/points.kt
+++ b/kandy-lets-plot/src/main/kotlin/org/jetbrains/kotlinx/kandy/letsplot/layers/points.kt
@@ -25,6 +25,7 @@ import org.jetbrains.kotlinx.kandy.letsplot.layers.context.PointsContext
  * * **`size`** - The size of the point.
  * * **`alpha`** - The transparency of the point.
  * * **`fillColor`** - The fill color for symbols that have a fill.
+ * * **`stroke`** - width of the shape border. Applied only to the shapes having border.
  *
  * ## Example
  *
@@ -43,6 +44,7 @@ import org.jetbrains.kotlinx.kandy.letsplot.layers.context.PointsContext
  *         color = Color.BLUE // Set a constant color for the points
  *         alpha = 0.7 // Set a constant transparency for the points
  *         fillColor = Color.GREEN // Set a fill color for the points (for filled symbols)
+ *         stroke = 3
  *
  *         // Map 'customerCounts' to 'size' to represent the number of customers as the size of the point
  *         size(customerCounts) {

--- a/kandy-lets-plot/src/main/kotlin/org/jetbrains/kotlinx/kandy/letsplot/translator/scaleWrap.kt
+++ b/kandy-lets-plot/src/main/kotlin/org/jetbrains/kotlinx/kandy/letsplot/translator/scaleWrap.kt
@@ -243,6 +243,7 @@ internal fun Scale.wrap(
                         barWidth = it.barWidth,
                         nbin = it.nBin
                     )
+
                     is LegendType.DiscreteLegend -> guideLegend(
                         nrow = it.nRow,
                         ncol = it.nCol,
@@ -254,7 +255,8 @@ internal fun Scale.wrap(
             when (this) {
                 is NonPositionalDefaultScale<*, *> -> if (
                     this is NonPositionalDefaultCategoricalScale<*, *> ||
-                    domainType.isCategoricalType() || aes in discreteAes || isGroupKey) {
+                    domainType.isCategoricalType() || aes in discreteAes || isGroupKey
+                ) {
                     NonPositionalCategoricalScale<String, String>(null, null).wrap(
                         aes,
                         domainType,
@@ -294,7 +296,8 @@ internal fun Scale.wrap(
                                 labels = labels,
                                 guide = legendType,
                                 format = format,
-                                naValue = naValue as? Number
+                                // TODO(fill NA for categorical)
+//                                naValue = naValue as? Number
                             )
                         }
 
@@ -429,36 +432,25 @@ internal fun Scale.wrap(
                 is NonPositionalContinuousScale<*, *> -> {
                     when (aes) {
 
-                        SIZE -> {
-                            // todo
-                            val range: Pair<Double, Double>? = if (rangeMin == null && rangeMax == null) {
-                                null
-                            } else {
-                                if (rangeMax == null) {
-                                    (rangeMin as Double).let {
-                                        it to it + 7.0
-                                    }
-                                } else if (rangeMin == null) {
-                                    (rangeMax as Double).let {
-                                        (it - 7.0).coerceAtLeast(0.2) to it
-                                    }
-                                } else {
-                                    rangeMin as Double to rangeMax as Double
-                                }
-                            }
-                            scaleSize(
-                                limits = (domainMin to domainMax).wrap(),
-                                range = range,//(rangeMin to rangeMax).wrap() as Pair<Number, Number>?, // todo!!
-                                name = name,
-                                breaks = breaks?.map { it as Number },
-                                labels = labels,
-                                guide = legendType,
-                                trans = (transform as Transformation?)?.name,
-                                format = format,
-                                naValue = naValue as? Number
-                            )
-                        }
+                        SIZE -> scaleSize(
+                            limits = (domainMin to domainMax).wrap(),
+                            range = (rangeMin to rangeMax).computeRange(),
+                            name = name,
+                            breaks = breaks?.map { it as Number },
+                            labels = labels,
+                            guide = legendType,
+                            trans = (transform as Transformation?)?.name,
+                            format = format,
+                            naValue = naValue as? Number
+                        )
 
+                        STROKE -> scaleStroke(
+                            range = (rangeMin to rangeMax).computeRange(), name = name,
+                            breaks = breaks?.map { it as? Number }, labels = labels,
+                            limits = (domainMin to domainMax).wrap(), naValue = naValue as? Number,
+                            format = format, guide = legendType,
+                            trans = (transform as? Transformation)?.name
+                        )
 
                         COLOR -> {
                             val lowColor = (rangeMin as? Color)?.wrap()

--- a/kandy-lets-plot/src/main/kotlin/org/jetbrains/kotlinx/kandy/letsplot/translator/util.kt
+++ b/kandy-lets-plot/src/main/kotlin/org/jetbrains/kotlinx/kandy/letsplot/translator/util.kt
@@ -8,9 +8,9 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.kandy.ir.data.GroupedData
 import org.jetbrains.kotlinx.kandy.ir.data.NamedData
 import org.jetbrains.kotlinx.kandy.ir.data.TableData
-import org.jetbrains.kotlinx.kandy.letsplot.util.SimpleValueWrapper
 import org.jetbrains.kotlinx.kandy.letsplot.settings.LineType
 import org.jetbrains.kotlinx.kandy.letsplot.settings.Symbol
+import org.jetbrains.kotlinx.kandy.letsplot.util.SimpleValueWrapper
 import org.jetbrains.kotlinx.kandy.util.color.Color
 import org.jetbrains.kotlinx.kandy.util.color.StandardColor
 
@@ -54,3 +54,10 @@ internal fun wrapValue(value: Any?): Any? {
 // TODO
 internal fun ClosedRange<*>?.wrap() = this?.let { (it.start as Number) to (it.endInclusive as Number) }
 internal fun Pair<*, *>?.wrap() = this?.let { (it.first as? Number) to (it.second as? Number) }
+
+internal fun Pair<Any?, Any?>.computeRange(): Pair<Double, Double>? = when {
+    first == null && second == null -> null
+    second == null && first is Double -> (first as Double).let { it to it + 7.0 }
+    first == null && second is Double -> (second as Double).let { (it - 7.0).coerceAtLeast(0.2) to it }
+    else -> first as Double to second as Double
+}

--- a/kandy-lets-plot/src/test/kotlin/org/jetbrains/kotlinx/kandy/letsplot/layers/context/pointRanges.kt
+++ b/kandy-lets-plot/src/test/kotlin/org/jetbrains/kotlinx/kandy/letsplot/layers/context/pointRanges.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlinx.kandy.letsplot.internal.FILL
 import org.jetbrains.kotlinx.kandy.letsplot.internal.LINE_TYPE
 import org.jetbrains.kotlinx.kandy.letsplot.internal.SHAPE
 import org.jetbrains.kotlinx.kandy.letsplot.internal.SIZE
+import org.jetbrains.kotlinx.kandy.letsplot.internal.STROKE
 import org.jetbrains.kotlinx.kandy.letsplot.internal.X
 import org.jetbrains.kotlinx.kandy.letsplot.internal.Y
 import org.jetbrains.kotlinx.kandy.letsplot.internal.Y_MAX
@@ -187,8 +188,9 @@ class InnerPointTests {
     private val symbol = listOf("rect").toColumn("symbol")
     private val color = listOf("blue").toColumn("color")
     private val fatten = listOf(0.5).toColumn("fatten")
+    private val stroke = listOf(1.5).toColumn("stroke")
 
-    private val df = dataFrameOf(symbol, color, fatten)
+    private val df = dataFrameOf(symbol, color, fatten, stroke)
 
     private val parentContext = DataFramePlotContext(df)
     private lateinit var context: InnerPointContext
@@ -244,6 +246,30 @@ class InnerPointTests {
     fun `symbol iterable mapping for innerPoint`() {
         context.symbol(listOf(1, 2, 3, 4))
         assertEquals("shape", (context.bindingCollector.mappings[SHAPE] as NonPositionalMapping<*, *>).columnID)
+    }
+
+    @Test
+    fun `stroke const for innerPoint`() {
+        context.stroke = 3.5
+        assertEquals(3.5, (context.bindingCollector.settings[STROKE] as NonPositionalSetting<*>).value)
+    }
+
+    @Test
+    fun `stroke str mapping for innerPoint`() {
+        context.stroke("stroke")
+        assertEquals("stroke", (context.bindingCollector.mappings[STROKE] as NonPositionalMapping<*, *>).columnID)
+    }
+
+    @Test
+    fun `stroke dataColumn mapping for innerPoint`() {
+        context.stroke(stroke)
+        assertEquals("stroke", (context.bindingCollector.mappings[STROKE] as NonPositionalMapping<*, *>).columnID)
+    }
+
+    @Test
+    fun `stroke iterable mapping for innerPoint`() {
+        context.stroke(listOf(1, 2, 3))
+        assertEquals("stroke", (context.bindingCollector.mappings[STROKE] as NonPositionalMapping<*, *>).columnID)
     }
 
     @Test

--- a/kandy-lets-plot/src/test/kotlin/org/jetbrains/kotlinx/kandy/letsplot/layers/context/points.kt
+++ b/kandy-lets-plot/src/test/kotlin/org/jetbrains/kotlinx/kandy/letsplot/layers/context/points.kt
@@ -6,6 +6,7 @@ import org.jetbrains.kotlinx.kandy.dsl.categorical
 import org.jetbrains.kotlinx.kandy.dsl.continuous
 import org.jetbrains.kotlinx.kandy.dsl.internal.DataFramePlotContext
 import org.jetbrains.kotlinx.kandy.ir.bindings.NonPositionalMapping
+import org.jetbrains.kotlinx.kandy.ir.bindings.NonPositionalMappingParameters
 import org.jetbrains.kotlinx.kandy.ir.bindings.NonPositionalSetting
 import org.jetbrains.kotlinx.kandy.ir.bindings.PositionalSetting
 import org.jetbrains.kotlinx.kandy.ir.scale.PositionalCategoricalScale
@@ -15,6 +16,7 @@ import org.jetbrains.kotlinx.kandy.letsplot.internal.COLOR
 import org.jetbrains.kotlinx.kandy.letsplot.internal.FILL
 import org.jetbrains.kotlinx.kandy.letsplot.internal.SHAPE
 import org.jetbrains.kotlinx.kandy.letsplot.internal.SIZE
+import org.jetbrains.kotlinx.kandy.letsplot.internal.STROKE
 import org.jetbrains.kotlinx.kandy.letsplot.internal.X
 import org.jetbrains.kotlinx.kandy.letsplot.internal.Y
 import org.jetbrains.kotlinx.kandy.letsplot.layers.geom.POINT
@@ -34,8 +36,9 @@ class PointsTests {
     private val fillColor = listOf("blue").toColumn("fillColor")
     private val alpha = listOf(0.5).toColumn("alpha")
     private val size = listOf(0.9).toColumn("size")
+    private val stroke = listOf(1.9).toColumn("stroke")
 
-    private val df = dataFrameOf(xAxis, yAxis, symbol, color, fillColor, alpha, size)
+    private val df = dataFrameOf(xAxis, yAxis, symbol, color, fillColor, alpha, size, stroke)
 
     private val parentContext = DataFramePlotContext(df)
     private lateinit var context: PointsContext
@@ -174,6 +177,32 @@ class PointsTests {
     fun `size iterable mapping for points`() {
         context.size(listOf(5, 10))
         assertEquals("size", (context.bindingCollector.mappings[SIZE] as NonPositionalMapping<*, *>).columnID)
+    }
+
+    @Test
+    fun `stroke const for points`() {
+        context.stroke = 3
+        assertEquals(3.0, (context.bindingCollector.settings[STROKE] as NonPositionalSetting<*>).value)
+    }
+
+    @Test
+    fun `stroke str mapping for points`() {
+        context.stroke("stroke")
+        assertEquals("stroke", (context.bindingCollector.mappings[STROKE] as NonPositionalMapping<*, *>).columnID)
+    }
+
+    @Test
+    fun `stroke dataColumn mapping for points`() {
+        context.stroke(stroke)
+        assertEquals("stroke", (context.bindingCollector.mappings[STROKE] as NonPositionalMapping<*, *>).columnID)
+    }
+
+    @Test
+    fun `stroke iterable mapping for points`() {
+        context.stroke(listOf(1.5, 8.0))
+        assertEquals("stroke", (context.bindingCollector.mappings[STROKE] as NonPositionalMapping<*, *>).columnID)
+        println(((context.bindingCollector.mappings[STROKE] as NonPositionalMapping<*, *>).parameters as NonPositionalMappingParameters).scale)
+
     }
 
     @Test


### PR DESCRIPTION
close #308

- Setting the same stroke value as in the lets-plot examples results in a larger thickness
- scaleStrokeIdentity() 

